### PR TITLE
Add seccomp userspace notification API to libseccomp-golang.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,9 @@ libseccomp-golang: Releases
 ===============================================================================
 https://github.com/seccomp/libseccomp-golang
 
+* Version 1.0.0 - Dec 12, 2019
+- Added support for the seccomp userspace notification API.
+
 * Version 0.9.1 - May 21, 2019
 - Minimum supported version of libseccomp bumped to v2.2.0
 - Use Libseccomp's `seccomp_version` API to retrieve library version

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/nestybox/libseccomp-golang
+
+go 1.13

--- a/seccomp.go
+++ b/seccomp.go
@@ -20,9 +20,10 @@ import (
 
 // C wrapping code
 
-// #cgo pkg-config: libseccomp
+// #cgo CFLAGS: -I../seccomp/include
+// #cgo LDFLAGS: -L../seccomp/src/.libs -lseccomp
 // #include <stdlib.h>
-// #include <seccomp.h>
+// #include "seccomp.h"
 import "C"
 
 // Exported types
@@ -69,8 +70,39 @@ type ScmpCondition struct {
 	Operand2 uint64        `json:"operand_two,omitempty"`
 }
 
-// ScmpSyscall represents a Linux System Call
+// Seccomp userspace notification structures associated with filters that use the ActNotify action.
+
+// ScmpSyscall identifies a Linux System Call by its number.
 type ScmpSyscall int32
+
+// ScmpFd represents a file-descriptor used for seccomp userspace notifications.
+type ScmpFd int32
+
+// ScmpNotifData describes the system call context that triggered a notification.
+type ScmpNotifData struct {
+	Syscall      ScmpSyscall `json:"syscall,omitempty"`
+	Arch         ScmpArch    `json:"arch,omitempty"`
+	InstrPointer uint64      `json:"instr_pointer,omitempty"`
+	Args         []uint64    `json:"args,omitempty"`
+}
+
+// ScmpNotifReq represents a seccomp userspace notification. See NotifReceive() for
+// further details.
+type ScmpNotifReq struct {
+	Id    uint64        `json:"id,omitempty"`
+	Pid   uint32        `json:"pid,omitempty"`
+	Flags uint32        `json:"flags,omitempty"`
+	Data  ScmpNotifData `json:"data,omitempty"`
+}
+
+// ScmpNotifResp represents a seccomp userspace notification response. See NotifRespond()
+// for further details.
+type ScmpNotifResp struct {
+	Id    uint64 `json:"id,omitempty"`
+	Val   uint64 `json:"val,omitempty"`
+	Error int32  `json:"error,omitempty"`
+	Flags uint32 `json:"flags,omitempty"`
+}
 
 // Exported Constants
 
@@ -129,6 +161,9 @@ const (
 	ActKill ScmpAction = iota
 	// ActTrap throws SIGSYS
 	ActTrap ScmpAction = iota
+	// ActNotify triggers a userspace notification. This action is only usable when
+	// libseccomp API level 5 or higher is supported.
+	ActNotify ScmpAction = iota
 	// ActErrno causes the syscall to return a negative error code. This
 	// code can be set with the SetReturnCode method
 	ActErrno ScmpAction = iota
@@ -170,6 +205,11 @@ const (
 	// CompareMaskedEqual returns true if the argument is equal to the given
 	// value, when masked (bitwise &) against the second given value
 	CompareMaskedEqual ScmpCompareOp = iota
+)
+
+const (
+	// Userspace notification response flags
+	NotifRespFlagContinue uint32 = 1
 )
 
 // Helpers for types
@@ -299,6 +339,8 @@ func (a ScmpAction) String() string {
 	case ActTrace:
 		return fmt.Sprintf("Action: Notify tracing processes with code %d",
 			(a >> 16))
+	case ActNotify:
+		return "Action: Notify userspace"
 	case ActLog:
 		return "Action: Log system call"
 	case ActAllow:
@@ -934,5 +976,91 @@ func (f *ScmpFilter) ExportBPF(file *os.File) error {
 		return errRc(retCode)
 	}
 
+	return nil
+}
+
+// Userspace Notification API
+
+// GetNotifFd returns the userspace notification file descriptor associated with the given
+// filter context. Such a file descriptor is only valid if the filter uses the ActNotify
+// action. The file descriptor can be used to retrieve and respond to notifications
+// associated with the filter (see NotifReceive(), NotifRespond(), and NotifIdValid()).
+func (f *ScmpFilter) GetNotifFd() (ScmpFd, error) {
+	f.lock.Lock()
+	defer f.lock.Unlock()
+
+	if !f.valid {
+		return -1, errBadFilter
+	}
+
+	api, apiErr := getApi()
+	if (apiErr != nil && api == 0) || (apiErr == nil && api < 5) {
+		return -1, fmt.Errorf("the seccomp notification API is only supported in libseccomp 2.4.0 and newer with API level 5 or higher")
+	}
+
+	fd := C.seccomp_notify_fd(f.filterCtx)
+
+	return ScmpFd(fd), nil
+}
+
+// NotifReceive retrieves a seccomp userspace notification from a filter whose ActNotify
+// action has triggered. The caller is expected to process the notification and return a
+// response via NotifRespond(). Each invocation of this function returns one
+// notification. As multiple notifications may be pending at any time, this function is
+// normally called within a polling loop.
+func NotifReceive(fd ScmpFd) (*ScmpNotifReq, error) {
+	var req *C.struct_seccomp_notif
+	var resp *C.struct_seccomp_notif_resp
+
+	// we only use the request here; the response is unused
+	if retCode := C.seccomp_notify_alloc(&req, &resp); retCode != 0 {
+		return nil, errRc(retCode)
+	}
+
+	defer func() {
+		C.free(unsafe.Pointer(req))
+		C.free(unsafe.Pointer(resp))
+	}()
+
+	if retCode := C.seccomp_notify_receive(C.int(fd), req); retCode != 0 {
+		return nil, errRc(retCode)
+	}
+
+	return notifReqFromNative(req)
+}
+
+// NotifRespond responds to a notification retrieved via NotifReceive. The response Id
+// must match that of an outstanding notification retrieved via NotifReceive.
+func NotifRespond(fd ScmpFd, scmpResp *ScmpNotifResp) error {
+	var req *C.struct_seccomp_notif
+	var resp *C.struct_seccomp_notif_resp
+
+	// we only use the reponse here; the request is discarded
+	if retCode := C.seccomp_notify_alloc(&req, &resp); retCode != 0 {
+		return errRc(retCode)
+	}
+
+	defer func() {
+		C.free(unsafe.Pointer(req))
+		C.free(unsafe.Pointer(resp))
+	}()
+
+	scmpResp.toNative(resp)
+
+	if retCode := C.seccomp_notify_respond(C.int(fd), resp); retCode != 0 {
+		return errRc(retCode)
+	}
+
+	return nil
+}
+
+// NotifIdValid checks if a notification is still valid. An return value of nil means the
+// notification is still valid. Otherwise the notification is not valid. This can be used
+// to mitigate time-of-check-time-of-use (TOCTOU) attacks by ensuring a notification is
+// valid just before responding to it.
+func NotifIdValid(fd ScmpFd, id uint64) error {
+	if retCode := C.seccomp_notify_id_valid(C.int(fd), C.uint64_t(id)); retCode != 0 {
+		return errRc(retCode)
+	}
 	return nil
 }

--- a/seccomp_internal.go
+++ b/seccomp_internal.go
@@ -14,7 +14,8 @@ import (
 // Get the seccomp header in scope
 // Need stdlib.h for free() on cstrings
 
-// #cgo pkg-config: libseccomp
+// #cgo CFLAGS: -I../seccomp/include
+// #cgo LDFLAGS: -L../seccomp/src/.libs -lseccomp
 /*
 #include <errno.h>
 #include <stdlib.h>
@@ -575,4 +576,48 @@ func (a scmpFilterAttr) toNative() uint32 {
 	default:
 		return 0x0
 	}
+}
+
+func (a ScmpSyscall) toNative() C.uint32_t {
+	return C.uint32_t(a)
+}
+
+func syscallFromNative(a C.int) ScmpSyscall {
+	return ScmpSyscall(a)
+}
+
+func notifReqFromNative(req *C.struct_seccomp_notif) (*ScmpNotifReq, error) {
+
+	scmpArgs := make([]uint64, 6)
+	for i := 0; i < len(scmpArgs); i++ {
+		scmpArgs[i] = uint64(req.data.args[i])
+	}
+
+	arch, err := archFromNative(req.data.arch)
+	if err != nil {
+		return nil, err
+	}
+
+	scmpData := ScmpNotifData{
+		Syscall:      syscallFromNative(req.data.nr),
+		Arch:         arch,
+		InstrPointer: uint64(req.data.instruction_pointer),
+		Args:         scmpArgs,
+	}
+
+	scmpReq := &ScmpNotifReq{
+		Id:    uint64(req.id),
+		Pid:   uint32(req.pid),
+		Flags: uint32(req.flags),
+		Data:  scmpData,
+	}
+
+	return scmpReq, nil
+}
+
+func (scmpResp *ScmpNotifResp) toNative(resp *C.struct_seccomp_notif_resp) {
+	resp.id = C.__u64(scmpResp.Id)
+	resp.val = C.__s64(scmpResp.Val)
+	resp.error = C.__s32(scmpResp.Error)
+	resp.flags = C.__u32(scmpResp.Flags)
 }


### PR DESCRIPTION
This commit adds the seccomp userspace notification API
present in version >= 2.4 of the libseccomp library.

This API allows userspace to get a notification when a filter
configured with a notification action triggers. The trigger suspends
processing of the syscall until the notification is delivered to
userspace and acknowledged back.