### PR TITLE
Fix cgo paths in libseccomp-golang.

### DIFF
--- a/seccomp_internal.go
+++ b/seccomp_internal.go
@@ -14,8 +14,8 @@ import (
 // Get the seccomp header in scope
 // Need stdlib.h for free() on cstrings
 
-// #cgo CFLAGS: -I../seccomp/include
-// #cgo LDFLAGS: -L../seccomp/src/.libs -l:libseccomp.a
+// #cgo CFLAGS: -I../libseccomp/include
+// #cgo LDFLAGS: -L../libseccomp/src/.libs -l:libseccomp.a
 /*
 #include <errno.h>
 #include <stdlib.h>


### PR DESCRIPTION
The fix is in seccomp_internal.go, which had the wrong path in the cgo CFGLAGS
and LDFLAGS.

The reason this had not broken things previously is that file seccomp.go has the
correct paths, and thus Golang finds the correct paths.

Signed-off-by: Cesar Talledo <ctalledo@nestybox.com>